### PR TITLE
added more poseidon commands.

### DIFF
--- a/agents/Poseidon/commands/c2.py
+++ b/agents/Poseidon/commands/c2.py
@@ -1,0 +1,112 @@
+import argparse
+from typing import List, Dict
+
+from cmd2 import cmd2, Cmd2ArgumentParser, argparse_custom
+
+from backend import Task
+from backend.mythic_agent.mythic_agent import AgentCommand, AgentCommandAlias, MythicAgent, add_default_options
+
+c2_parser = Cmd2ArgumentParser()
+c2_subparsers = c2_parser.add_subparsers(title='subcommands', help='subcommand help')
+
+c2_start_parser = c2_subparsers.add_parser('start', help='Start a C2 profile')
+c2_start_parser.add_argument('profile', help='The name of the c2 profile you want to configure')
+add_default_options(c2_start_parser)
+
+c2_stop_parser = c2_subparsers.add_parser('stop', help='Stop a C2 profile')
+c2_stop_parser.add_argument('profile', help='The name of the c2 profile you want to configure')
+add_default_options(c2_stop_parser)
+
+c2_update_parser = c2_subparsers.add_parser('update', help='Update C2 Profile')
+c2_update_parser.add_argument('profile', help='The name of the c2 profile you want to update')
+c2_update_parser.add_argument('name', help='The name of the c2 profile attribute you want to adjust')
+c2_update_parser.add_argument('value', help='The new value you want to use')
+add_default_options(c2_update_parser)
+
+
+class C2(AgentCommand):
+    def __init__(self, agent: MythicAgent):
+        super().__init__(agent=agent)
+        self._name = "c2"
+        self._subcommand_parsers: Dict[str, argparse_custom.Cmd2ArgumentParser] = {
+            "start": c2_start_parser,
+            "stop": c2_stop_parser,
+            "update": c2_update_parser,
+        }
+        self._aliases = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def aliases(self) -> List[AgentCommandAlias]:
+        return self._aliases
+
+    @property
+    def subcommand_parsers(self) -> Dict[str, cmd2.argparse_custom.Cmd2ArgumentParser]:
+        return self._subcommand_parsers
+
+    @property
+    def command_parser(self) -> cmd2.argparse_custom.Cmd2ArgumentParser:
+        return c2_parser
+
+    @cmd2.with_argparser(c2_parser, preserve_quotes=True)
+    def do_c2(self, args):
+        func = getattr(args, 'func', None)
+        if func is not None:
+            return func(self, args)
+
+    def c2_start(self, args: argparse.Namespace | str) -> Task:
+        if isinstance(args, str):
+            args = c2_start_parser.parse_args(args)
+
+        command_args = {
+            "c2_name": args.profile,
+            "action": "start"
+        }
+
+        task = Task(self._agent.instance, command="update_c2", args=command_args,
+                    callback_display_id=self._agent.tasker.callback.display_id)
+
+        task.console_args = args
+        task.background = args.background
+        return task
+
+    c2_start_parser.set_defaults(func=c2_start)
+
+    def c2_stop(self, args: argparse.Namespace | str) -> Task:
+        if isinstance(args, str):
+            args = c2_start_parser.parse_args(args)
+
+        command_args = {
+            "c2_name": args.profile,
+            "action": "stop"
+        }
+
+        task = Task(self._agent.instance, command="update_c2", args=command_args,
+                    callback_display_id=self._agent.tasker.callback.display_id)
+
+        task.console_args = args
+        task.background = args.background
+        return task
+
+    c2_stop_parser.set_defaults(func=c2_stop)
+
+    def c2_update(self, args: str | argparse.Namespace) -> Task:
+        if isinstance(args, str):
+            args = c2_update_parser.parse_args(args)
+
+        command_args = {
+            "c2_name": args.profile,
+            "config_name": args.name,
+            "config_value": args.value
+        }
+        task = Task(self._agent.instance, command="update_c2", args=command_args,
+                    callback_display_id=self._agent.tasker.callback.display_id)
+
+        task.console_args = args
+        task.background = args.background
+        return task
+
+    c2_update_parser.set_defaults(func=c2_update)

--- a/agents/Poseidon/commands/file.py
+++ b/agents/Poseidon/commands/file.py
@@ -1,10 +1,14 @@
 import argparse
-from typing import List, Dict
+from pathlib import Path
+from typing import List, Dict, Coroutine
 
 from cmd2 import cmd2, Cmd2ArgumentParser, argparse_custom
+from mythic import mythic
 
 from backend import Task
 from backend.mythic_agent.mythic_agent import AgentCommand, AgentCommandAlias, MythicAgent, add_default_options
+from backend.task.task import TaskError
+from utils.logger import logger
 
 file_parser = Cmd2ArgumentParser()
 file_subparsers = file_parser.add_subparsers(title='subcommands', help='subcommand help')
@@ -20,8 +24,15 @@ add_default_options(file_cat_parser)
 
 file_head_parser = file_subparsers.add_parser('head', help='Read the first X lines from a file')
 file_head_parser.add_argument('path', help='Path to the file to read')
-file_head_parser.add_argument('lines', type=int, help='Number of lines to read from the beginning of a file')
+file_head_parser.add_argument('--lines', default=20, type=int,
+                              help='Number of lines to read from the beginning of a file')
 add_default_options(file_head_parser)
+
+file_tail_parser = file_subparsers.add_parser('tail', help='Read the last X lines from a file')
+file_tail_parser.add_argument('path', help='Path to the file to read')
+file_tail_parser.add_argument('--lines', default=20, type=int,
+                              help='Number of lines to read from the end of a file')
+add_default_options(file_tail_parser)
 
 file_move_parser = file_subparsers.add_parser('move', help='Move a file')
 file_move_parser.add_argument('source', help='source path')
@@ -31,6 +42,12 @@ add_default_options(file_move_parser)
 file_download_parser = file_subparsers.add_parser('download', help='Download a file from the target')
 file_download_parser.add_argument('path', nargs='+', help='path to file to download')
 add_default_options(file_download_parser)
+
+file_upload_parser = file_subparsers.add_parser('upload', help='Upload a file to the target')
+file_upload_parser.add_argument('local_path', help='Local path of file to upload')
+file_upload_parser.add_argument('remote_path', help='Remote path of file to upload')
+file_upload_parser.add_argument('--overwrite', action='store_true', help='Overwrite if file exists')
+add_default_options(file_upload_parser)
 
 file_remove_parser = file_subparsers.add_parser('remove', help='Remove a file')
 file_remove_parser.add_argument('path', nargs='+', help='path to file to remove')
@@ -47,15 +64,19 @@ class File(AgentCommand):
             "move": file_move_parser,
             "cat": file_cat_parser,
             "head": file_head_parser,
+            "tail": file_tail_parser,
             "remove": file_remove_parser,
+            "upload": file_upload_parser,
         }
         self._aliases = [
             AgentCommandAlias("cp", self._name, "copy"),
             AgentCommandAlias("cat", self._name, "cat"),
             AgentCommandAlias("download", self._name, "download"),
             AgentCommandAlias("head", self._name, "head"),
+            AgentCommandAlias("tail", self._name, "tail"),
             AgentCommandAlias("mv", self._name, "move"),
             AgentCommandAlias("rm", self._name, "remove"),
+            AgentCommandAlias("upload", self._name, "upload"),
         ]
 
     @property
@@ -100,8 +121,7 @@ class File(AgentCommand):
 
     def file_cat(self, args: str | argparse.Namespace) -> Task:
         if isinstance(args, str):
-            subcommand_parser = file_cat_parser
-            args = subcommand_parser.parse_args(args)
+            args = file_cat_parser.parse_args(args)
 
         path = " ".join(args.path)
         task = Task(self._agent.instance, command="cat", args=path,
@@ -115,8 +135,7 @@ class File(AgentCommand):
 
     def file_head(self, args: str | argparse.Namespace) -> Task:
         if isinstance(args, str):
-            subcommand_parser = file_cat_parser
-            args = subcommand_parser.parse_args(args)
+            args = file_cat_parser.parse_args(args)
 
         command_args = {
             "path": args.path,
@@ -130,6 +149,24 @@ class File(AgentCommand):
         return task
 
     file_head_parser.set_defaults(func=file_head)
+
+    def file_tail(self, args: str | argparse.Namespace) -> Task:
+        if isinstance(args, str):
+            args = file_tail_parser.parse_args(args)
+
+        command_args = {
+            "path": args.path,
+            "lines": args.lines,
+        }
+
+        task = Task(self._agent.instance, command="tail", args=command_args,
+                    callback_display_id=self._agent.tasker.callback.display_id)
+
+        task.console_args = args
+        task.background = args.background
+        return task
+
+    file_tail_parser.set_defaults(func=file_tail)
 
     def file_move(self, args: argparse.Namespace | str) -> Task:
         if isinstance(args, str):
@@ -176,3 +213,35 @@ class File(AgentCommand):
         return task
 
     file_remove_parser.set_defaults(func=file_remove)
+
+    async def file_upload(self, args: argparse.Namespace | str) -> Task:
+        if isinstance(args, str):
+            args = file_upload_parser.parse_args(args)
+
+        try:
+            local_path = Path(args.local_path)
+            with open(local_path, 'rb') as f:
+                data = f.read()
+
+            file_id = await mythic.register_file(self._agent.instance.mythic, filename=local_path.name, contents=data)
+
+            command_args = {
+                "file_id": file_id,
+                "remote_path": args.remote_path,
+                "overwrite": args.overwrite
+            }
+
+            task = Task(self._agent.instance, command="upload", args=command_args,
+                        callback_display_id=self._agent.tasker.callback.display_id)
+
+            task.console_args = args
+            task.background = args.background
+            await task.execute()
+            if not task.background:
+                await task.wait_for_completion()
+
+            return task
+        except Exception as e:
+            raise TaskError(e)
+
+    file_upload_parser.set_defaults(func=file_upload)

--- a/agents/Poseidon/commands/file.py
+++ b/agents/Poseidon/commands/file.py
@@ -1,6 +1,6 @@
 import argparse
 from pathlib import Path
-from typing import List, Dict, Coroutine
+from typing import List, Dict
 
 from cmd2 import cmd2, Cmd2ArgumentParser, argparse_custom
 from mythic import mythic
@@ -8,7 +8,6 @@ from mythic import mythic
 from backend import Task
 from backend.mythic_agent.mythic_agent import AgentCommand, AgentCommandAlias, MythicAgent, add_default_options
 from backend.task.task import TaskError
-from utils.logger import logger
 
 file_parser = Cmd2ArgumentParser()
 file_subparsers = file_parser.add_subparsers(title='subcommands', help='subcommand help')

--- a/agents/Poseidon/commands/sleep.py
+++ b/agents/Poseidon/commands/sleep.py
@@ -1,0 +1,53 @@
+import argparse
+from typing import List, Dict
+
+from cmd2 import cmd2, Cmd2ArgumentParser
+
+from backend import Task
+from backend.mythic_agent.mythic_agent import AgentCommand, MythicAgent, AgentCommandAlias, add_default_options
+
+sleep_parser = Cmd2ArgumentParser(description="Update the sleep interval of the agent.")
+add_default_options(sleep_parser)
+sleep_parser.add_argument('--interval', type=int, help='Interval Seconds')
+sleep_parser.add_argument('--jitter', type=int, help='Jitter Percentage')
+
+
+class Sleep(AgentCommand):
+    def __init__(self, agent: MythicAgent):
+        super().__init__(agent)
+        self._name = "sleep"
+        self._subcommand_parsers: Dict[str, cmd2.argparse_custom.Cmd2ArgumentParser] = {}
+        self._aliases = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def subcommand_parsers(self) -> Dict[str, cmd2.argparse_custom.Cmd2ArgumentParser]:
+        return self._subcommand_parsers
+
+    @property
+    def command_parser(self) -> cmd2.argparse_custom.Cmd2ArgumentParser:
+        return sleep_parser
+
+    @property
+    def aliases(self) -> List[AgentCommandAlias]:
+        return self._aliases
+
+    @cmd2.with_argparser(sleep_parser)
+    def do_sleep(self, args: argparse.Namespace | str) -> Task:
+        if isinstance(args, str):
+            args = sleep_parser.parse_args(args)
+
+        command_args = {
+            "interval": args.interval,
+            "jitter": args.jitter,
+        }
+
+        task = Task(self._agent.instance, command="sleep", args=command_args,
+                    callback_display_id=self._agent.tasker.callback.display_id)
+
+        task.console_args = args
+        task.background = args.background
+        return task

--- a/agents/Poseidon/commands/socks.py
+++ b/agents/Poseidon/commands/socks.py
@@ -1,0 +1,95 @@
+import argparse
+from typing import List, Dict
+
+from cmd2 import cmd2, Cmd2ArgumentParser, argparse_custom
+
+from backend import Task
+from backend.mythic_agent.mythic_agent import AgentCommand, AgentCommandAlias, MythicAgent, add_default_options
+
+socks_parser = Cmd2ArgumentParser(description="Start or Stop SOCKS5.")
+socks_subparsers = socks_parser.add_subparsers(title='subcommands', help='subcommand help')
+
+socks_start_parser = socks_subparsers.add_parser('start', help='Start SOCKS5 proxy')
+socks_start_parser.add_argument('--port', type=int, default=7000,
+                                help='Port number on Mythic server to open for SOCKS5')
+socks_start_parser.add_argument('--username', help='Optionally restrict access to SOCKS port via username/password')
+socks_start_parser.add_argument('--password', help='Optionally restrict access to SOCKS port via username/password')
+add_default_options(socks_start_parser)
+
+socks_stop_parser = socks_subparsers.add_parser('stop', help='Stop a port forward')
+socks_stop_parser.add_argument('--port', type=int, default=7000,
+                               help='Port number on Mythic server to open for SOCKS5')
+add_default_options(socks_stop_parser)
+
+
+class Socks(AgentCommand):
+    def __init__(self, agent: MythicAgent):
+        super().__init__(agent=agent)
+        self._name = "socks"
+        self._subcommand_parsers: Dict[str, argparse_custom.Cmd2ArgumentParser] = {
+            "start": socks_start_parser,
+            "stop": socks_stop_parser,
+        }
+        self._aliases = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def aliases(self) -> List[AgentCommandAlias]:
+        return self._aliases
+
+    @property
+    def subcommand_parsers(self) -> Dict[str, cmd2.argparse_custom.Cmd2ArgumentParser]:
+        return self._subcommand_parsers
+
+    @property
+    def command_parser(self) -> cmd2.argparse_custom.Cmd2ArgumentParser:
+        return socks_parser
+
+    @cmd2.with_argparser(socks_parser)
+    def do_socks(self, args):
+        func = getattr(args, 'func', None)
+        if func is not None:
+            return func(self, args)
+
+    def socks_start(self, args: argparse.Namespace | str) -> Task:
+        if isinstance(args, str):
+            args = socks_start_parser.parse_args(args)
+
+        command_args = {
+            "action": "start",
+            "port": args.port,
+            "username": args.username or "",
+            "password": args.password or "",
+        }
+
+        task = Task(self._agent.instance, command="socks", args=command_args,
+                    callback_display_id=self._agent.tasker.callback.display_id)
+
+        task.console_args = args
+        task.background = args.background
+        return task
+
+    socks_start_parser.set_defaults(func=socks_start)
+
+    def socks_stop(self, args: str | argparse.Namespace) -> Task:
+        if isinstance(args, str):
+            args = socks_stop_parser.parse_args(args)
+
+        command_args = {
+            "action": "stop",
+            "port": args.port,
+            "username": "",
+            "password": "",
+        }
+
+        task = Task(self._agent.instance, command="socks", args=command_args,
+                    callback_display_id=self._agent.tasker.callback.display_id)
+
+        task.console_args = args
+        task.background = args.background
+        return task
+
+    socks_stop_parser.set_defaults(func=socks_stop)

--- a/agents/Poseidon/commands/ssh.py
+++ b/agents/Poseidon/commands/ssh.py
@@ -1,0 +1,109 @@
+from typing import List, Dict
+
+from cmd2 import cmd2, argparse_custom, Cmd2ArgumentParser
+
+from backend import Task
+from backend.mythic_agent.mythic_agent import AgentCommand, AgentCommandAlias, MythicAgent, add_default_options
+
+ssh_parser = Cmd2ArgumentParser()
+directory_subparsers = ssh_parser.add_subparsers(title='subcommands', help='subcommand help')
+
+ssh_execute_parser = directory_subparsers.add_parser('execute', help='list a directory')
+add_default_options(ssh_execute_parser)
+ssh_execute_parser.add_argument('--hosts', nargs='+', default=["127.0.0.1"], help='Hosts that you will auth to')
+ssh_execute_parser.add_argument('--username', required=True,
+                                help='Authenticate to the designated hosts using this username')
+ssh_execute_parser.add_argument('--command', required=True, help='command to run on  host')
+ssh_execute_parser.add_argument('--port', type=int, default=22, help='SSH Port if different than 22')
+exec_auth_group = ssh_execute_parser.add_mutually_exclusive_group()
+exec_auth_group.add_argument('--password', help='Authenticate to the designated hosts using this password')
+exec_auth_group.add_argument('--key', help='Authenticate to the designated hosts using this private key')
+
+ssh_copy_parser = directory_subparsers.add_parser('copy', help='SCP a file to remote host')
+add_default_options(ssh_copy_parser)
+ssh_copy_parser.add_argument('source', help='path to file to copy')
+ssh_copy_parser.add_argument('destination', help='destination to copy file to')
+ssh_copy_parser.add_argument('--hosts', nargs='+', default=["127.0.0.1"], help='Hosts that you will auth to')
+ssh_copy_parser.add_argument('--username', help='Authenticate to the designated hosts using this username')
+ssh_copy_parser.add_argument('--port', type=int, default=22, help='SSH Port if different than 22')
+copy_auth_group = ssh_copy_parser.add_mutually_exclusive_group()
+copy_auth_group.add_argument('--password', help='Authenticate to the designated hosts using this password')
+copy_auth_group.add_argument('--key', help='Authenticate to the designated hosts using this private key')
+
+
+class Ssh(AgentCommand):
+    def __init__(self, agent: MythicAgent):
+        super().__init__(agent=agent)
+        self._name = "ssh"
+        self._subcommand_parsers: Dict[str, argparse_custom.Cmd2ArgumentParser] = {
+            "execute": ssh_execute_parser,
+            "copy": ssh_copy_parser,
+        }
+        self._aliases = [
+            AgentCommandAlias("scp", self._name, "copy"),
+        ]
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def aliases(self) -> List[AgentCommandAlias]:
+        return self._aliases
+
+    @property
+    def subcommand_parsers(self) -> Dict[str, cmd2.argparse_custom.Cmd2ArgumentParser]:
+        return self._subcommand_parsers
+
+    @property
+    def command_parser(self) -> cmd2.argparse_custom.Cmd2ArgumentParser:
+        return ssh_parser
+
+    @cmd2.with_argparser(ssh_parser)
+    def do_ssh(self, args):
+        func = getattr(args, 'func', None)
+        if func is not None:
+            return func(self, args)
+
+    def ssh_execute(self, args) -> Task:
+        if isinstance(args, str):
+            args = ssh_execute_parser.parse_args(args)
+
+        command_args = {
+            "username": args.username,
+            "password": args.password,
+            "private_key": args.key,
+            "hosts": args.hosts,
+            "port": args.port,
+            "command": args.command
+        }
+        task = Task(self._agent.instance, command="sshauth", args=command_args,
+                    callback_display_id=self._agent.tasker.callback.display_id)
+
+        task.console_args = args
+        task.background = args.background
+        return task
+
+    ssh_execute_parser.set_defaults(func=ssh_execute)
+
+    def ssh_copy(self, args) -> Task:
+        if isinstance(args, str):
+            args = ssh_copy_parser.parse_args(args)
+
+        command_args = {
+            "username": args.username,
+            "password": args.password,
+            "private_key": args.key,
+            "hosts": args.hosts,
+            "port": args.port,
+            "source": args.source,
+            "destination": args.destination,
+        }
+        task = Task(self._agent.instance, command="sshauth", args=command_args,
+                    callback_display_id=self._agent.tasker.callback.display_id)
+
+        task.console_args = args
+        task.background = args.background
+        return task
+
+    ssh_copy_parser.set_defaults(func=ssh_copy)

--- a/screens/home.py
+++ b/screens/home.py
@@ -317,7 +317,6 @@ class Home(Screen):
 
             worker = None
             if isinstance(resp, Task):
-                logger.info("here")
                 if resp.verify_prompt:
                     if not await self.app.push_screen_wait(resp.verify_prompt):
                         logger.debug("user bailed on task")
@@ -332,7 +331,6 @@ class Home(Screen):
                                          exit_on_error=False)
 
             if isinstance(resp, Coroutine):
-                logger.info("here")
                 worker = self.run_worker(resp, exit_on_error=False)
 
             if not worker:


### PR DESCRIPTION
- Added remain commands that work on Linux/Mac (still need to implement mac-specific):
  - c2 (start/stop/update)
  - sleep
  - upload
  - socks
  - ssh  (non-pty)
  - pwd
  - unsetenv

- Added  ability to make command function `async` in  case users need to `await`  functions. This occurs in `upload` for  example, where the file must be registered  with Mythic before starting the task.
- Set the default formatter for Poseidon commands to `format_plaintext`

